### PR TITLE
samtools added to the environment file

### DIFF
--- a/workflow/envs/mapdamage.yaml
+++ b/workflow/envs/mapdamage.yaml
@@ -5,3 +5,4 @@ channels:
 dependencies:
   - mapdamage2
   - parallel
+  - samtools


### PR DESCRIPTION
samtools is missing in the mapdamage environment file