### PR TITLE
switch to abundance quantification in python

### DIFF
--- a/workflow/rules/malt.smk
+++ b/workflow/rules/malt.smk
@@ -58,6 +58,7 @@ rule Malt_QuantifyAbundance:
         sam="results/MALT/{sample}.trimmed.sam.gz",
     params:
         unique_taxids="results/KRAKENUNIQ_ABUNDANCE_MATRIX/unique_species_taxid_list.txt",
+        exe=WORKFLOW_DIR / "scripts/malt_quantify_abundance.py",
     log:
         "logs/MALT_QUANTIFY_ABUNDANCE/{sample}.log",
     benchmark:
@@ -65,7 +66,7 @@ rule Malt_QuantifyAbundance:
     message:
         "Malt_QuantifyAbundance: QUANTIFYING MICROBIAL ABUNDANCE USING MALT SAM-ALIGNMENTS FOR SAMPLE {input.sam}"
     shell:
-        """n_species=0; touch {output.counts}; for i in $(cat {params.unique_taxids}); do zgrep \"|tax|$i\" {input.sam} | grep -v '@' | awk '!a[$1]++' | wc -l >> {output.counts} || true; n_species=$((n_species+1)); echo Finished $n_species species; done &> {log}"""
+        """{params.exe} {input.sam} {params.unique_taxids} > {output.counts} 2> {log}"""
 
 
 rule Malt_AbundanceMatrix_Sam:

--- a/workflow/scripts/malt_quantify_abundance.py
+++ b/workflow/scripts/malt_quantify_abundance.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import gzip
+from sys import argv
+
+sam = argv[1]
+ids = argv[2]
+
+counts = {}
+read_ids = set()
+taxids = []
+
+with open(ids) as id_file:
+    for id in id_file:
+        counts[id.strip()] = 0
+        taxids.append(id.strip())
+
+with gzip.open(sam) as sam_file:
+    # M_ST-E00266:253:HCK7GCCXY:1:1101:20577:16463       0       AK125553.1|tax|63363    ...
+    for read in sam_file:
+        if "@" not in read:
+            split_read = read.split()
+            read_id = split_read[0]
+            taxid = split_read[2].split("|")[-1]
+            if (
+                taxid in counts and (taxid, read_id) not in read_ids
+            ):  # want to avoid counting duplicate reads
+                counts[taxid] += 1
+                read_ids.add((taxid, read_id))
+
+for taxid in taxids:
+    print(counts[taxid])


### PR DESCRIPTION
Here, we introduce a simple python script to count occurrences of taxids from one text file in a gzipped sam file. Tests look good, but we can't be absolutely sure that they are correct since the code in the original pipeline contains bugs

Fixes #68 