### PR TITLE
Add -p to mkdir in case folder exists

### DIFF
--- a/workflow/rules/authentic.smk
+++ b/workflow/rules/authentic.smk
@@ -17,7 +17,7 @@ checkpoint Create_Sample_TaxID_Directories:
         dir=lambda wildcards: f"results/AUTHENTICATION/{wildcards.sample}",
     shell:
         "mkdir -p {params.dir}; "
-        "while read taxid; do mkdir {params.dir}/$taxid; touch {params.dir}/$taxid/.done; done<{input.pathogens};"
+        "while read taxid; do mkdir -p {params.dir}/$taxid; touch {params.dir}/$taxid/.done; done<{input.pathogens};"
         "touch {output.done}"
 
 


### PR DESCRIPTION
This small detail will make that the pipeline won't fail when rerunning it if the folder was already created. It was failing before.