### PR TITLE
Fix pheatmap integer formatting bug in KrakenUniq_AbundanceMatrix heatmap

### DIFF
--- a/workflow/rules/krakenuniq.smk
+++ b/workflow/rules/krakenuniq.smk
@@ -88,6 +88,8 @@ rule KrakenUniq_AbundanceMatrix:
         unique_species_names="results/KRAKENUNIQ_ABUNDANCE_MATRIX/unique_species_names_list.txt",
         abundance_matrix="results/KRAKENUNIQ_ABUNDANCE_MATRIX/krakenuniq_abundance_matrix.txt",
         abundance_plot="results/KRAKENUNIQ_ABUNDANCE_MATRIX/krakenuniq_absolute_abundance_heatmap.pdf",
+        normalized_abundance_plot="results/KRAKENUNIQ_ABUNDANCE_MATRIX/krakenuniq_normalized_abundance_heatmap.pdf",
+        top20_abundance_plot="results/KRAKENUNIQ_ABUNDANCE_MATRIX/krakenuniq_top20_abundance_heatmap.pdf",
     input:
         expand("results/KRAKENUNIQ/{sample}/krakenuniq.output.filtered", sample=SAMPLES),
     log:

--- a/workflow/scripts/plot_krakenuniq_abundance_matrix.R
+++ b/workflow/scripts/plot_krakenuniq_abundance_matrix.R
@@ -1,55 +1,96 @@
-#This is a script for plotting KrakenUniq abundance matrix.
-#Run this script as:
-#Rscript plot_krakenuniq_abundance_matrix.R in_dir out_dir
+# This is a script for plotting KrakenUniq abundance matrix.
+# Run this script as:
+# Rscript plot_krakenuniq_abundance_matrix.R in_dir out_dir
 
-args = commandArgs(trailingOnly=TRUE)
-in_dir<-as.character(args[1])
-out_dir<-as.character(args[2])
+args <- commandArgs(trailingOnly = TRUE)
+in_dir <- as.character(args[1])
+out_dir <- as.character(args[2])
 
 library("pheatmap")
-ku_abundance<-read.delim(paste0(in_dir,"/krakenuniq_abundance_matrix.txt"),header=TRUE,row.names=1,check.names=FALSE,sep="\t")
 
+# Read abundance matrix and convert to numeric matrix
+ku_abundance <- read.delim(paste0(in_dir, "/krakenuniq_abundance_matrix.txt"),
+                           header = TRUE, row.names = 1, check.names = FALSE, sep = "\t")
+ku_abundance <- as.matrix(ku_abundance)
 
-#FUNCTION FOR TUNING FONTSIZE ON MICROBIAL ABUNDANCE HEATMAP
-my_fontsize<-function(ku_abundance)
-{
-  if(dim(ku_abundance)[1]<50){return(12)}
-  else if(dim(ku_abundance)[1]>=50 & dim(ku_abundance)[1]<100){return(10)}
-  else if(dim(ku_abundance)[1]>=100 & dim(ku_abundance)[1]<150){return(8)}
-  else{return(6)}
+# Create a version of the matrix for display, rounded for readability
+ku_abundance_display <- round(ku_abundance)
+
+# Function for tuning font size on microbial abundance heatmap
+my_fontsize <- function(mat) {
+  if (nrow(mat) < 50) {
+    return(12)
+  } else if (nrow(mat) < 100) {
+    return(10)
+  } else if (nrow(mat) < 150) {
+    return(8)
+  } else {
+    return(6)
+  }
 }
 
+# Absolute abundance heatmap
+pdf(paste0(out_dir, "/krakenuniq_absolute_abundance_heatmap.pdf"), paper = "a4r", width = 297, height = 210)
+if (nrow(ku_abundance) > 1 & ncol(ku_abundance) > 1) {
+  pheatmap(ku_abundance, display_numbers = ku_abundance_display, fontsize = my_fontsize(ku_abundance),
+           main = "KrakenUniq Absolute Microbial Abundance", cluster_rows = FALSE, cluster_cols = FALSE,
+           number_format = "%i")
+} else {
+  pheatmap(ku_abundance, display_numbers = ku_abundance_display, fontsize = 8,
+           main = "KrakenUniq Absolute Microbial Abundance", cluster_rows = FALSE, cluster_cols = FALSE,
+           number_format = "%i", breaks = c(0, 1))
+}
+dev.off()
 
-#ABSOLUTE ABUNDANCE HEATMAP
-pdf(paste0(out_dir,"/krakenuniq_absolute_abundance_heatmap.pdf"),paper="a4r",width=297,height=210)
-if(dim(ku_abundance)[1]>1 & dim(ku_abundance)[2]>1)
-{
-  pheatmap(ku_abundance, display_numbers=TRUE,fontsize=my_fontsize(ku_abundance),
-           main="KrakenUniq Absolute Microbial Abundance",cluster_rows=FALSE,cluster_cols=FALSE,number_format="%i")
-}else
-{
-  pheatmap(ku_abundance, display_numbers=TRUE,fontsize=8,
-           main="KrakenUniq Absolute Microbial Abundance",cluster_rows=FALSE,cluster_cols=FALSE,number_format="%i",breaks=c(0,1))
+# Normalise by sequencing depth (column-wise)
+for (i in 1:ncol(ku_abundance)) {
+  ku_abundance[, i] <- ku_abundance[, i] / sum(ku_abundance[, i])
+}
+ku_abundance_display <- round(ku_abundance, digits = 3)
+
+# Normalised abundance heatmap
+pdf(paste0(out_dir, "/krakenuniq_normalized_abundance_heatmap.pdf"), paper = "a4r", width = 297, height = 210)
+if (nrow(ku_abundance) > 1 & ncol(ku_abundance) > 1) {
+  pheatmap(ku_abundance, display_numbers = ku_abundance_display, fontsize = my_fontsize(ku_abundance),
+           main = "KrakenUniq Normalized Microbial Abundance", cluster_rows = FALSE, cluster_cols = FALSE,
+           number_format = "%.3f")
+} else {
+  pheatmap(ku_abundance, display_numbers = ku_abundance_display, fontsize = 8,
+           main = "KrakenUniq Normalized Microbial Abundance", cluster_rows = FALSE, cluster_cols = FALSE,
+           number_format = "%.3f", breaks = c(0, 1))
 }
 dev.off()
 
+# Top 20 species × their most enriched samples (including Homo sapiens)
+top_n <- 20
+species_sums <- rowSums(ku_abundance_display)
 
-#NORMALIZE BY SEQUENCING SEPTH
-for(i in 1:dim(ku_abundance)[2])
-{
-  ku_abundance[,i]<-ku_abundance[,i]/sum(ku_abundance[,i])
+# Get top N species (including Homo sapiens)
+top_species <- names(sort(species_sums, decreasing = TRUE))[1:min(top_n, length(species_sums))]
+
+# Subset matrices
+ku_top <- ku_abundance[top_species, , drop = FALSE]
+ku_top_display <- ku_abundance_display[top_species, , drop = FALSE]
+
+# Get most enriched sample per species
+top_samples <- apply(ku_top, 1, function(x) names(which.max(x)))
+selected_samples <- unique(top_samples)[1:min(top_n, length(unique(top_samples)))]
+
+# Subset to selected samples
+ku_top <- ku_top[, selected_samples, drop = FALSE]
+ku_top_display <- ku_top_display[, selected_samples, drop = FALSE]
+
+# Plot focused heatmap (20xN)
+if (nrow(ku_top) > 0 & ncol(ku_top) > 0) {
+  pdf(paste0(out_dir, "/krakenuniq_top", top_n, "x", ncol(ku_top), "_abundance_heatmap.pdf"), paper = "a4r", width = 297, height = 210)
+  if (nrow(ku_top) > 1 & ncol(ku_top) > 1) {
+    pheatmap(ku_top, display_numbers = ku_top_display, fontsize = my_fontsize(ku_top),
+             main = paste0("Top ", nrow(ku_top), " Species × Top ", ncol(ku_top), " Samples"),
+             cluster_rows = FALSE, cluster_cols = FALSE, number_format = "%i")
+  } else {
+    pheatmap(ku_top, display_numbers = ku_top_display, fontsize = 8,
+             main = paste0("Top ", nrow(ku_top), " Species × Top ", ncol(ku_top), " Samples"),
+             cluster_rows = FALSE, cluster_cols = FALSE, number_format = "%i", breaks = c(0, 1))
+  }
+  dev.off()
 }
-
-
-#ABSOLUTE ABUNDANCE HEATMAP
-pdf(paste0(out_dir,"/krakenuniq_normalized_abundance_heatmap.pdf"),paper="a4r",width=297,height=210)
-if(dim(ku_abundance)[1]>1 & dim(ku_abundance)[2]>1)
-{
-  pheatmap(ku_abundance, display_numbers=TRUE,fontsize=my_fontsize(ku_abundance),
-           main="KrakenUniq Normalized Microbial Abundance",cluster_rows=FALSE,cluster_cols=FALSE,number_format="%.3f")
-}else
-{
-  pheatmap(ku_abundance, display_numbers=TRUE,fontsize=8,
-           main="KrakenUniq Normalized Microbial Abundance",cluster_rows=FALSE,cluster_cols=FALSE,number_format="%.3f",breaks=c(0,1))
-}
-dev.off()

--- a/workflow/scripts/plot_krakenuniq_abundance_matrix.R
+++ b/workflow/scripts/plot_krakenuniq_abundance_matrix.R
@@ -85,11 +85,11 @@ if (nrow(ku_top) > 0 & ncol(ku_top) > 0) {
   pdf(paste0(out_dir, "/krakenuniq_top", top_n, "_abundance_heatmap.pdf"), paper = "a4r", width = 297, height = 210)
   if (nrow(ku_top) > 1 & ncol(ku_top) > 1) {
     pheatmap(ku_top, display_numbers = ku_top_display, fontsize = my_fontsize(ku_top),
-             main = paste0("Top ", nrow(ku_top), " Species × Top ", ncol(ku_top), " Samples"),
+             main = "Top taxa by normalised KrakenUniq abundance",
              cluster_rows = FALSE, cluster_cols = FALSE, number_format = "%i")
   } else {
     pheatmap(ku_top, display_numbers = ku_top_display, fontsize = 8,
-             main = paste0("Top ", nrow(ku_top), " Species × Top ", ncol(ku_top), " Samples"),
+             main = "Top taxa by normalised KrakenUniq abundance",
              cluster_rows = FALSE, cluster_cols = FALSE, number_format = "%i", breaks = c(0, 1))
   }
   dev.off()

--- a/workflow/scripts/plot_krakenuniq_abundance_matrix.R
+++ b/workflow/scripts/plot_krakenuniq_abundance_matrix.R
@@ -82,7 +82,7 @@ ku_top_display <- ku_top_display[, selected_samples, drop = FALSE]
 
 # Plot focused heatmap (20xN)
 if (nrow(ku_top) > 0 & ncol(ku_top) > 0) {
-  pdf(paste0(out_dir, "/krakenuniq_top", top_n, "x", ncol(ku_top), "_abundance_heatmap.pdf"), paper = "a4r", width = 297, height = 210)
+  pdf(paste0(out_dir, "/krakenuniq_top", top_n, "_abundance_heatmap.pdf"), paper = "a4r", width = 297, height = 210)
   if (nrow(ku_top) > 1 & ncol(ku_top) > 1) {
     pheatmap(ku_top, display_numbers = ku_top_display, fontsize = my_fontsize(ku_top),
              main = paste0("Top ", nrow(ku_top), " Species × Top ", ncol(ku_top), " Samples"),


### PR DESCRIPTION
## Fix pheatmap formatting error in KrakenUniq abundance heatmap script

This PR fixes a `pheatmap()` crash in the KrakenUniq abundance plotting script caused by large numeric values in the abundance matrix.

### Background

In deeply sequenced samples, the `taxReads` values can exceed 2³¹. This causes R to promote the matrix from `integer` to `numeric`, which leads to a `sprintf()` error when using `number_format = "%i"`.

### What this fix does

- Explicitly rounds the abundance matrix before passing it to `display_numbers` in `pheatmap()` with these commands "ku_abundance <- as.matrix(ku_abundance) and "ku_abundance_display <- round(ku_abundance)
- Creates a `ku_abundance_display` matrix with rounded values:
  - Rounded to 0 decimals for absolute values
  - Rounded to 3 decimals for normalised values
- Prevents type mismatch in `sprintf()` while preserving original values in the heatmap itself

### Additional improvements

- Adds an optional focused heatmap (`krakenuniq_top20xN_abundance_heatmap.pdf`) showing the 20 most abundant species across their most enriched samples, to improve readability in dense matrices
- Corrected a comment typo: `"NORMALIZE BY SEQUENCING SEPTH"` with `"Normalise by sequencing depth"`
- Corrected a comment title: "#ABSOLUTE ABUNDANCE HEATMAP" with "# Normalised abundance heatmap"
- Cleaned up indentation and spacing (no change to logic)

### Testing

The script was tested on a real dataset, including deeply sequenced samples that previously triggered the error. All heatmaps now generate successfully.
