### PR TITLE
Update malt.yaml with imagemagick

### DIFF
--- a/workflow/envs/malt.yaml
+++ b/workflow/envs/malt.yaml
@@ -8,3 +8,4 @@ dependencies:
   - samtools
   - seqtk
   - megan
+  - imagemagick


### PR DESCRIPTION
Adds imagemagick to the malt.yaml environment to support PNG export in Authentication_Plots via the convert command.

Fixes #196.