### PR TITLE
Add `set -e` to prevent `.initdb` creation if initialisation fails

### DIFF
--- a/.test/runtest.sh
+++ b/.test/runtest.sh
@@ -27,6 +27,7 @@ fi
 # check if we are running CI; if not, initialize databases
 if [[ -z "$CI" ]]; then
     if [[ ! -e ".initdb" ]]; then
+        set -e  # <- exit immediately on failure
         echo "This looks like the first test run... Installing bioconda packages..."
         snakemake --conda-frontend $CONDA_FRONTEND --use-conda --show-failed-logs -j 1 --conda-cleanup-pkgs cache --conda-create-envs-only -s ../workflow/Snakefile
 

--- a/.test/runtest.sh
+++ b/.test/runtest.sh
@@ -28,7 +28,6 @@ fi
 # check if we are running CI; if not, initialize databases
 if [[ -z "$CI" ]]; then
     if [[ ! -e ".initdb" ]]; then
-        set -e  # <- exit immediately on failure
         echo "This looks like the first test run... Installing bioconda packages..."
         snakemake --conda-frontend $CONDA_FRONTEND --use-conda --show-failed-logs -j 1 --conda-cleanup-pkgs cache --conda-create-envs-only -s ../workflow/Snakefile
 

--- a/.test/runtest.sh
+++ b/.test/runtest.sh
@@ -1,3 +1,4 @@
+set -e # <- exit immediately on failure
 conda_version=$(conda --version | awk '{print $2}')
 conda_major=$(echo $conda_version | awk -F. '{print $1}')
 conda_minor=$(echo $conda_version | awk -F. '{print $2}')


### PR DESCRIPTION
This is a quick fix for a recurring issue where the first test run fails— often due to insufficient memory allocation—yet still creates the `.initdb` marker file. As a result, future runs skip the initialisation block even though key setup steps (like KrakenUniq DB or Krona taxonomy) weren't completed properly.

Adding `set -e` ensures that the script exits immediately on any error, preventing `.initdb` from being created unless all steps have succeeded.

This will fix a very recurring problems with new users failing to run the aMeta test. It will fix issue #195 and #194 

We could do a fancier fix, but I don't have time right now. 