### PR TITLE
Fix version-related issues in Snakemake environments

### DIFF
--- a/workflow/envs/environment.v8.yaml
+++ b/workflow/envs/environment.v8.yaml
@@ -6,8 +6,8 @@ channels:
 
 dependencies:
   # core packages for workflow
-  - python>=3.11
-  - snakemake-minimal>=8
+  - python>=3.10,<3.12
+  - snakemake-minimal>=8,<9
   - snakemake-storage-plugin-http
   - mamba
   - pandas

--- a/workflow/envs/environment.v8.yaml
+++ b/workflow/envs/environment.v8.yaml
@@ -9,6 +9,7 @@ dependencies:
   - python>=3.10,<3.12
   - snakemake-minimal>=8,<9
   - snakemake-storage-plugin-http
+  - setuptools<81
   - mamba
   - pandas
   - biopython
@@ -34,6 +35,6 @@ dependencies:
   - jinja2
   - networkx
   - pygraphviz
-  - imagemagick
+  - imagemagick<8
   - graphviz
   - pandoc

--- a/workflow/envs/environment.v8.yaml
+++ b/workflow/envs/environment.v8.yaml
@@ -10,6 +10,7 @@ dependencies:
   - snakemake-minimal>=8,<9
   - snakemake-storage-plugin-http
   - setuptools<81
+  - conda>=24.7.1
   - mamba
   - pandas
   - biopython

--- a/workflow/envs/environment.yaml
+++ b/workflow/envs/environment.yaml
@@ -6,7 +6,7 @@ channels:
 
 dependencies:
   # core packages for workflow
-  - python>=3.11
+  - python>=3.10,<3.12
   - snakemake-minimal>=6.0,<8
   - mamba
   - pandas

--- a/workflow/envs/environment.yaml
+++ b/workflow/envs/environment.yaml
@@ -9,6 +9,7 @@ dependencies:
   - python>=3.10,<3.12
   - snakemake-minimal>=6.0,<8
   - mamba
+  - setuptools<81
   - pandas
   - biopython
   - fastqc>=0.12.1
@@ -33,6 +34,6 @@ dependencies:
   - jinja2
   - networkx
   - pygraphviz
-  - imagemagick
+  - imagemagick<8
   - graphviz
   - pandoc


### PR DESCRIPTION
## Summary

This PR improves long-term compatibility of the legacy Snakemake environments by adding version constraints to key dependencies.

Changes:
- Restrict Python to >=3.10,<3.12
- Restrict Snakemake 8 environment to Snakemake <9
- Add setuptools<81 to avoid pkg_resources deprecation issues
- Restrict ImageMagick to <8 to avoid future incompatibilities with the deprecated convert command
- Add conda>=24.7.1 to the Snakemake 8 environment

Both environment.yaml and environment.v8.yaml were recreated from scratch and successfully tested using the aMeta test dataset.

Closes #202
Closes #210
Closes #213